### PR TITLE
NGINX: In default.conf, added SSL certificates which are mounted in /…

### DIFF
--- a/public-interface/nginx/default.conf
+++ b/public-interface/nginx/default.conf
@@ -1,5 +1,12 @@
 server {
-  listen 80;
+
+  listen	      80;
+  listen              443 default ssl;
+  #server_name        your.server.name;
+  ssl_certificate     /etc/ssl/server.cert;
+  ssl_certificate_key /etc/ssl/server.key;
+  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
   root /usr/share/nginx/html;
 
   location / {


### PR DESCRIPTION
…etc/ssl

Server now listens to 443 and 80

It is on a v1.0b branch because it is a fix for the v1.0 release tag. The result will be tagged with v1.0.1 once aligned with the paltform-launcher repo. Hence it will not be committed to master. Later we can pick it to the developoer branch once we have it stable (and stable aligned with master).
Note that this only works with another commit in platform launcher. Nevertheless, I need first this in the repo to reference the right commit in the submodule when I commit the rest to platform-launcher