### PR TITLE
NGINX: In default.conf, added SSL certificates which are mounted in /…

### DIFF
--- a/public-interface/nginx/default.conf
+++ b/public-interface/nginx/default.conf
@@ -1,5 +1,12 @@
 server {
-  listen 80;
+
+  listen	      80;
+  listen              443 default ssl;
+  #server_name        your.server.name;
+  ssl_certificate     /etc/ssl/server.cert;
+  ssl_certificate_key /etc/ssl/server.key;
+  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
   root /usr/share/nginx/html;
 
   location / {


### PR DESCRIPTION
…etc/ssl

Server now listens to 443 and 80
This should be done in parallel with platformlauncher PR #44