### PR TITLE
Fix bug: rewrite query to get componentType and updateComponent

### DIFF
--- a/public-interface/iot-entities/postgresql/componentTypes.js
+++ b/public-interface/iot-entities/postgresql/componentTypes.js
@@ -72,7 +72,8 @@ exports.findByIdAndAccount = function (compId, accountId, t) {
                 },
                 {
                     accountId: null,
-                    componentTypeId: compId
+                    componentTypeId: compId,
+                    default: true
                 }
             ]
         },
@@ -95,7 +96,23 @@ exports.findByIdAndAccount = function (compId, accountId, t) {
 };
 
 exports.findByDimensionAndAccount = function (dimension, accountId, t) {
-    return componentTypes.findAll({where: {accountId: accountId, dimension: dimension}, transaction: t})
+	var query = {
+	        where: {
+	            $or: [
+	                {
+	                    accountId: accountId,
+	                    dimension: dimension
+	                },
+	                {
+	                    accountId: null,
+	                    dimension: dimension,
+	                    default: true
+	                }
+	            ]
+	        },
+	        transaction: t
+	    };
+    return componentTypes.findAll(query)
         .then(function (component) {
             return Q.resolve(interpreterHelper.mapAppResults(component, interpreter));
         });


### PR DESCRIPTION
Because the default componentTypes do not have any accountId, there was a bug when updating a componentType, by getComponent before this was solved by letting the accountId to be null, which we cannot do here since it would mean we could get a component which does not belong to the account that is requesting. That is why we must check if it is a default type, and then allow the update. Just checking accountId is null at getComponent is also risky(cause it could still allow to get a component that does not belong to the specific account which is requesting), that is why I added there the check of default too.