### PR TITLE
Change time format at /v1/api/auth/tokenInfo end point to timestamp format

### DIFF
--- a/public-interface/lib/security/authorization.js
+++ b/public-interface/lib/security/authorization.js
@@ -88,10 +88,13 @@ var getTokenInfo = function(token, req, callback){
 
         var header = jws.getParsedHeader();
         var payload = jws.getParsedPayload();
+    	var expireDate = new Date(payload.exp);
 
-        if(new Date() > new Date(payload.exp)){
+        if(new Date() > expireDate){
             callback();
         } else {
+        	var timestamp = expireDate.getTime();
+        	payload.exp = timestamp;
             var result = {
                 header: header,
                 payload: payload


### PR DESCRIPTION
Time format at /v1/api/auth/tokenInfo is changed to timestamp format to prevent inconsistencies mentioned here: [#50](https://github.com/Open-IoT-Service-Platform/oisp-frontend/issues/50)