### PR TITLE
Fix bug: /v1/api/auth/me can't be triggered, add comment about /auth/…

### DIFF
--- a/public-interface/lib/security/authentication.js
+++ b/public-interface/lib/security/authentication.js
@@ -248,6 +248,7 @@ module.exports = function (cfg, forceSSL) {
 
     passport.use(localStrategy);
 
+    app.get('/api/auth/me', getCurrentUser);
     app.get('/auth/me', getCurrentUser);
 
     app.put('/auth/me', refreshToken,

--- a/public-interface/lib/security/config/routes.config.js
+++ b/public-interface/lib/security/config/routes.config.js
@@ -132,6 +132,12 @@ module.exports = [
 
     ["/dashboard",                               verbs.GET,          "ui:public"                             ],
     ["/validate",                                verbs.GET,          "ui:public"                             ],
+
+    /*The endpoint /auth/me implements the login service at dashboard user interface.
+      The GET method is currently implemented for the REST API as well.
+      If it is needed, others can be too, to do that: Add the route here just like below,
+      also specify what it will do at ../authentication.js (e.g app.put('/api/auth/me', ...))*/
+    ["/api/auth/me",                             verbs.GET,          "user:admin",    36000                  ],
     ["/auth/me",                                 verbs.GET,          "user:admin",    36000                  ],
     ["/auth/me",                                 verbs.DELETE,       "user:admin",    36000                  ],
     ["/auth/me",                                 verbs.PUT,          "user:admin",    36000                  ],


### PR DESCRIPTION
This solves the bug issued at: [#35](https://github.com/Open-IoT-Service-Platform/oisp-frontend/issues)

The problem was there was no endpoint created for /api/auth/me. This caused that the route could not be authorized, therefore it gave the error: Not Authorized. The same function that gets the user information of the token owner getCurrentUser is used for the /ui/auth/me endpoint for login services. Only the GET method is added for the REST API, as the other methods (PUT, DELETE) are not relevant for the REST API, but they are needed for the dashboard ui. A comment is added to routes.config that this could be changed in the future if needed.