### PR TITLE
Remove external files to container

### DIFF
--- a/public-interface/Dockerfile
+++ b/public-interface/Dockerfile
@@ -1,5 +1,13 @@
-FROM node:6.13.1
+FROM node:6-alpine
 
+RUN apk update; apk add ncurses make bash
+
+ADD ./package.json /app/package.json
 WORKDIR /app
+
+RUN npm install
+
+ADD . /app
+RUN node_modules/grunt-cli/bin/grunt build-api
 
 EXPOSE 4001

--- a/public-interface/Dockerfile
+++ b/public-interface/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 RUN npm install
 
 ADD . /app
+ENV TERM xterm
 RUN node_modules/grunt-cli/bin/grunt build-api
 
 EXPOSE 4001

--- a/public-interface/scripts/database/V00.00.01_00__create_user_with_iot_schema.sql
+++ b/public-interface/scripts/database/V00.00.01_00__create_user_with_iot_schema.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.01_00__create_user_with_iot_schema.sql

--- a/public-interface/scripts/database/V00.00.02_00__components.sql
+++ b/public-interface/scripts/database/V00.00.02_00__components.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.02_00__components.sql

--- a/public-interface/scripts/database/V00.00.03_00__activate_device.sql
+++ b/public-interface/scripts/database/V00.00.03_00__activate_device.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.03_00__activate_device.sql

--- a/public-interface/scripts/database/V00.00.04_00__add_device_components.sql
+++ b/public-interface/scripts/database/V00.00.04_00__add_device_components.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.04_00__add_device_components.sql

--- a/public-interface/scripts/database/V00.00.05_00__create_user.sql
+++ b/public-interface/scripts/database/V00.00.05_00__create_user.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.05_00__create_user.sql

--- a/public-interface/scripts/database/V00.00.06_00__create_account.sql
+++ b/public-interface/scripts/database/V00.00.06_00__create_account.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.06_00__create_account.sql

--- a/public-interface/scripts/database/V00.00.07_00__update_user.sql
+++ b/public-interface/scripts/database/V00.00.07_00__update_user.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.07_00__update_user.sql

--- a/public-interface/scripts/database/V00.00.08_00__update_device_connection.sql
+++ b/public-interface/scripts/database/V00.00.08_00__update_device_connection.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.08_00__update_device_connection.sql

--- a/public-interface/scripts/database/V00.00.12_00__add_support_for_incremental_export.sql
+++ b/public-interface/scripts/database/V00.00.12_00__add_support_for_incremental_export.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.12_00__add_support_for_incremental_export.sql

--- a/public-interface/scripts/database/V00.00.13_00_alert_comments.sql
+++ b/public-interface/scripts/database/V00.00.13_00_alert_comments.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.13_00_alert_comments.sql

--- a/public-interface/scripts/database/V00.00.14_00_alter_alert.sql
+++ b/public-interface/scripts/database/V00.00.14_00_alter_alert.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.14_00_alter_alert.sql

--- a/public-interface/scripts/database/V00.00.15_00_alter_rule.sql
+++ b/public-interface/scripts/database/V00.00.15_00_alter_rule.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.15_00_alter_rule.sql

--- a/public-interface/scripts/database/V00.00.16_00__alter_commands.sql
+++ b/public-interface/scripts/database/V00.00.16_00__alter_commands.sql
@@ -1,0 +1,1 @@
+./public-interface/deploy/postgres/base/V00.00.16_00__alter_commands.sql


### PR DESCRIPTION
App and .sql files are not data accessed by externals, but rather internal components and therefore belong inside the container. Merge this at the same time with the parallel request in platform-launcher.