### PR TITLE
Update nginx Dockerfile.

### DIFF
--- a/public-interface/nginx/Dockerfile
+++ b/public-interface/nginx/Dockerfile
@@ -1,3 +1,5 @@
+FROM oisp/frontend
+
 FROM nginx:1.13.1
 
 ARG WEBSOCKET_SERVER
@@ -8,7 +10,9 @@ ADD default.conf /etc/nginx/conf.d/default.conf
 RUN sed -i 's/localhost:5000/'"$WEBSOCKET_SERVER"'/g' /etc/nginx/conf.d/default.conf
 RUN sed -i 's/localhost:4001/'"$DASHBOARD_SERVER"'/g' /etc/nginx/conf.d/default.conf
 RUN sed -i 's|/opt/dashboard/iotkit-dashboard/dashboard/public/|/app/dashboard/public/|g' /etc/nginx/conf.d/default.conf
-RUN sed -i '/root/a \ \ resolver 127.0.0.11;' /etc/nginx/conf.d/default.conf 
+RUN sed -i '/root/a \ \ resolver 127.0.0.11;' /etc/nginx/conf.d/default.conf
+
+COPY --from=0 /app /app
 
 EXPOSE 80
 EXPOSE 443

--- a/public-interface/nginx/Dockerfile
+++ b/public-interface/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM oisp/frontend
 
-FROM nginx:1.13.1
+FROM nginx:1.13.1-alpine
 
 ARG WEBSOCKET_SERVER
 ARG DASHBOARD_SERVER


### PR DESCRIPTION
Now the container contains the data nginx hosts, eliminating the need
for an external mount.

This commit should not break anything, but for it to take effect when the platform is started via make start, we need to remove the volume mount (parallel PR to platform-launcher coming soon)

In order to compile the container to be compatible with a specific version of frontend, specify this version on the first line of multi-stage build.