### PR TITLE
Fix bug: Cannot edit device in GUI

### DIFF
--- a/public-interface/dashboard/public/js/controllers/devices/addEditDevice.js
+++ b/public-interface/dashboard/public/js/controllers/devices/addEditDevice.js
@@ -90,6 +90,10 @@ iotController.controller('AddEditDeviceCtrl', function($scope,
     };
 
     $scope.saveDevice = function(){
+    	var loc = $scope.device.loc;
+    	loc.latitude = typeof loc.latitude !== "number" ? parseFloat(loc.latitude) : loc.latitude;
+    	loc.longitude = typeof loc.longitude !== "number" ? parseFloat(loc.longitude) : loc.longitude;
+    	loc.height = typeof loc.height !== "number" ? parseFloat(loc.height) : loc.height;
         if($scope.addMode){
             devicesService.addDevice($scope.device, function(){
                 goToDevices();


### PR DESCRIPTION
This resolves #65, after the sequelize update, node-pg is converting decimal values to strings to prevent precision lost. This forces angular to parse the values coming from postgres, which we have done in the other areas but forgot in the location field of device. Now the location field is parsed properly, everything should be back on track. 