### PR TITLE
Change token expire date format to timestamp convention

### DIFF
--- a/public-interface/lib/security/authorization.js
+++ b/public-interface/lib/security/authorization.js
@@ -47,7 +47,7 @@ var generateToken = function(subjectId, accounts, role, expire, callback){
         jti: uuid.v4(),
         iss: iss,
         sub: subjectId,
-        exp: expireDate,
+        exp: expireDate.getTime(),
         accounts: accounts
     };
 


### PR DESCRIPTION
This change is necessary because at Node.js v8 the module that checks the JWT token wants that the expire date is in timestamp format.