### PR TITLE
Prevent postgres updating timestamps when sending data

### DIFF
--- a/public-interface/engine/api/v1/data.js
+++ b/public-interface/engine/api/v1/data.js
@@ -82,14 +82,6 @@ exports.collectData = function (options, resultCallback) {
                             submitData = proxy.submitDataREST;
                         }
 
-                        //Connecting with AA API
-                        Object.keys(latestObservationTimes).forEach(function (cid) {
-                            Component.updateLastObservationTS(cid, latestObservationTimes[cid], function (err) {
-                                if(err) {
-                                    logger.error("Error occured when updating last observation timestamp for component " + cid + ": " + err);
-                                }
-                            });
-                        });
                         Object.keys(oldObservationTimes).forEach(function (cid) {
                             DeviceComponentMissingExportDays.addHistoricalDaysWithDataIfNotExisting(cid, oldObservationTimes[cid], function (err) {
                                 if(err) {
@@ -97,11 +89,6 @@ exports.collectData = function (options, resultCallback) {
                                 }
                             });
                         });
-                        //Updating last visit
-                        DevicesAPI.updateLastVisit(deviceId)
-                            .catch(function(err) {
-                               logger.warn('Error occurred while updating device lastVisit, err - ' + JSON.stringify(err));
-                            });
 
                         logger.debug("Data to Send: " + JSON.stringify(data));
                         submitData(data, function (err) {

--- a/public-interface/iot-entities/postgresql/devices.js
+++ b/public-interface/iot-entities/postgresql/devices.js
@@ -271,21 +271,6 @@ exports.addComponents = function (components, deviceId, accountId, transaction) 
         });
 };
 
-exports.updateLastVisit = function (deviceId) {
-
-    var filter = {
-        where: {
-            id: deviceId
-        }
-    };
-    var lastVisit = new Date();
-
-    return devices.update({lastVisit: lastVisit}, filter)
-        .catch(function (err) {
-            throw err;
-        });
-};
-
 exports.getTotals = function (accountId, resultCallback) {
 
     var filter = {

--- a/public-interface/iot-entities/postgresql/models/devices.js
+++ b/public-interface/iot-entities/postgresql/models/devices.js
@@ -48,8 +48,7 @@ module.exports = function (sequelize, DataTypes) {
                 type: DataTypes.ENUM('active', 'created'),
                 allowNull: false,
                 defaultValue: 'created'
-            },
-            lastVisit:DataTypes.DATE
+            }
         },
         {
             createdAt: 'created',


### PR DESCRIPTION
This prevents updating timestamps of the devices and its components. The entity for the timestamps is also removed since it will not be used anymore.