### PR TITLE
Fix mailer/websocket-executor logger bug: Mailer logs preview url of …

### DIFF
--- a/public-interface/config.js
+++ b/public-interface/config.js
@@ -169,7 +169,6 @@ var config = {
         level: 'info', //Default verbosity,
     	format: winston.format.combine(
     	        winston.format.colorize(),
-    	        winston.format.simple(),
     	        winston.format.timestamp(),
     	        winston.format.printf(info => { return `${info.timestamp}-${info.level}: ${info.message}`; })
     	     ),

--- a/public-interface/lib/event-monitor/executors/executor-ws.js
+++ b/public-interface/lib/event-monitor/executors/executor-ws.js
@@ -56,7 +56,7 @@ module.exports = function() {
 
                     logger.debug("Device " + bind.deviceId + " was connected last time to " + bind.server + " websocket server");
 
-                    logger.info("Sending message to Websocket. Message: " + message);
+                    logger.info("Sending message to Websocket. Message: " + JSON.stringify(message));
                     var connector = connectWithWebsocket(bind.server);
                     connector.publish(message);
                 })

--- a/public-interface/lib/mailer.js
+++ b/public-interface/lib/mailer.js
@@ -80,7 +80,7 @@ var sendMail = function (templateName, params, smtpConfig) {
 	}).then(res => {
 		logger.info(JSON.stringify(res.originalMessage));
 		if (process.env.TEST && (process.env.TEST.toLowerCase().indexOf("1") !== -1)) {
-            console.log('Preview URL: %s', nodemailer.getTestMessageUrl(info));
+            logger.info('Preview URL: ' + JSON.stringify(nodemailer.getTestMessageUrl(res)));
         }
 	}).catch(err => {
 		logger.error('mailer. send, error sending the mail: ' + JSON.stringify(err));


### PR DESCRIPTION
…the email, executor-ws shows the sended message correctly.

Removed winston.format.simple from the formating config, it was interfering with
winston.format.printf, and printf actually does the job of simple too.

The message at executor-ws is now stringified. (This was bugged at Node.js v6 as well)

Changed the variable name at mailer so it fits with the function parameter. This was not caught before, due to previous bug at logger with error messages #76.

With this all logger bugs at v8 (after #72)  should be resolved.