### PR TITLE
DataSubmission API refactoring in order to:

### DIFF
--- a/public-interface/buildscripts/jshint/config.json
+++ b/public-interface/buildscripts/jshint/config.json
@@ -12,6 +12,7 @@
     "unused": true,
     "indent": false,
     "node" : true,
+    "esversion": 6,
     "globals": {
         "angular": true,
         "Rickshaw": true,

--- a/public-interface/engine/handlers/v1/data.js
+++ b/public-interface/engine/handlers/v1/data.js
@@ -30,7 +30,8 @@ exports.collectData = function (req, res, next) {
         deviceId: req.params.deviceId,
         data: req.body,
         forwarded: req.headers['forwarded'] || false,
-        gatewayId: req.identity
+        identity: req.identity,
+        type: req.tokenInfo.payload.type
     };
 
     data.collectData(options, function(err) {

--- a/public-interface/engine/res/errors.js
+++ b/public-interface/engine/res/errors.js
@@ -120,6 +120,7 @@ module.exports = {
         },
         Data: {
             InvalidData: {code: 6400, status: 400, message: "Invalid data for Target Filter"},
+            PartialDataProcessed: {code: 6402, status: 404, message: "Only part of the data has been submitted successfully"},
             FormatError: {code: 6500, status: 500, message: "Format not accepted"},
             OffsetAndLimitBothOrNoneRequired:{code:6504, status:404, message:"offset and limit must be specified both or none"},
             WrongResponseCodeFromAA: {code: 6506, status: 500, message: "Could not send data."},

--- a/public-interface/iot-entities/postgresql/deviceComponents.js
+++ b/public-interface/iot-entities/postgresql/deviceComponents.js
@@ -128,6 +128,26 @@ exports.getByCustomFilter = function(accountId, customFilter, resultCallback) {
     });
 };
 
+exports.findComponentsAndTypesForDevice = function(deviceId, resultCallback) {
+  var filter = {
+    where: {
+      deviceId: deviceId
+    },
+    include: [
+    {
+      model: componentTypes
+    }]
+  };
+  deviceComponents.findAll(filter)
+  .then(function(result) {
+    interpreterHelper.mapAppResults(result, interpreter, resultCallback);
+  })
+  .catch(function(err) {
+    console.log(err);
+    resultCallback(err);
+  });
+};
+
 exports.updateLastObservationTS = function (componentId, date, resultCallback) {
     var filter = {
         where: {

--- a/public-interface/iot-entities/postgresql/devices.js
+++ b/public-interface/iot-entities/postgresql/devices.js
@@ -462,4 +462,22 @@ exports.deleteComponent = function (deviceId, componentId, transaction) {
         });
 };
 
-
+exports.belongsToAccount = function(deviceId, accountId) {
+  var filter = {
+    where: {
+      accountId: accountId,
+      id: deviceId
+    }
+  };
+  return devices.findOne(filter)
+  .then(function(result) {
+    return new Promise(function(resolve, reject) {
+      if (result !== undefined && result !== null) {
+        resolve();
+      }
+      else {
+        reject();
+      }
+    });
+  });
+};

--- a/public-interface/lib/advancedanalytics-proxy/Metric.data.js
+++ b/public-interface/lib/advancedanalytics-proxy/Metric.data.js
@@ -32,7 +32,8 @@ Metric.prototype.dataAsRoot = function (value) {
     var dataTemporal = {
         "cid": value.componentId || value.cid || this.globalCid,
         "on": value.on || this.on,
-        "value": value.v || value.value
+        "value": value.v || value.value,
+        "dataType": value.dataType
     };
     if (value.loc) {
         dataTemporal.loc = value.loc;

--- a/public-interface/lib/security/authorization.js
+++ b/public-interface/lib/security/authorization.js
@@ -249,7 +249,9 @@ var authorizeRoute = function (req, res, next) {
             next();
         } else {
             if (req.path.indexOf('/api/') === 0) {
-                res.status(errBuilder.Errors.Generic.NotAuthorized.code).send(errBuilder.Errors.Generic.NotAuthorized.message);
+              var err = errBuilder.build(
+                errBuilder.Errors.Generic.NotAuthorized.code);
+                res.status(errBuilder.Errors.Generic.NotAuthorized.code).send(err);
             } else {
                 res.redirect('/');
             }

--- a/public-interface/lib/security/config/roles.config.js
+++ b/public-interface/lib/security/config/roles.config.js
@@ -31,7 +31,6 @@ module.exports = {
     ],
     user: [
         "data:read",
-        "data:write",
         "device:admin",
         "device:read",
 


### PR DESCRIPTION
* Allow account admins to send test data to devices (without the gateway naming restriction)
* Add additional data base lookup only for non-device tokens
* Forbid normal users to send test data to devices, but access can be changed in the security config if needed
* Send additionally the dataType of observations to the backend to allow different handling of data types (e.g. precondition for handling binary data)

This is closing Issue#82