### PR TITLE
Added CBOR middleware for binary data handling

### DIFF
--- a/public-interface/app.js
+++ b/public-interface/app.js
@@ -40,6 +40,7 @@ var http = require('http'),
     systemUsers = require('./lib/dp-users/systemUsers'),
     forceSSL = require('express-force-ssl'),
     heartBeat = require('./lib/heartbeat');
+    const cbor = require("./lib/cbor");
 
 var XSS = iotRoutes.cors,
     appServer = express(),
@@ -73,7 +74,9 @@ if (config.api.forceSSL) {
 appServer.use('/ui/public', express.static('dashboard/public'));
 
 appServer.use(httpHeadersInjector.forwardedHeaders);
-appServer.use(bodyParser.json({limit: config.api.bodySizeLimit}));
+appServer.use(bodyParser.raw({limit: config.api.bodySizeLimit, type: "application/cbor"}));
+appServer.use(cbor.parseCborBody);
+appServer.use(bodyParser.json({limit: config.api.bodySizeLimit, type: "application/json"}));
 appServer.use(bodyParser.urlencoded({extended: true, limit: config.api.bodySizeLimit}));
 appServer.use(XSS());
 

--- a/public-interface/engine/api/v1/data.js
+++ b/public-interface/engine/api/v1/data.js
@@ -97,6 +97,7 @@ exports.collectData = function(options, resultCallback) {
                         data.deviceId = deviceId;
                         data.systemOn = Date.now();
                         data.data = filteredData;
+                        data.hasBinary = options.hasBinary;
                         var submitData = proxy.submitDataKafka;
                         if (config.drsProxy.ingestion === 'REST') {
                             submitData = proxy.submitDataREST;
@@ -209,10 +210,10 @@ exports.search = function(accountId, searchRequest, resultCallback) {
                     delete searchRequest.targetFilter;
                     logger.debug("search Request: " + JSON.stringify(searchRequest));
                     if (Object.keys(componentsWithDataType).length > 0) {
-                        proxy.dataInquiry(searchRequest, function(err, result) {
+                        proxy.dataInquiry(searchRequest, function(err, result, isBinary) {
                             if (!err) {
                                 var response = new DataInquiryResponse(result, deviceLookUp, searchRequest.queryMeasureLocation);
-                                resultCallback(null, response);
+                                resultCallback(null, response, isBinary);
                             } else if (result) {
                                 resultCallback(err, result);
                             } else {
@@ -303,9 +304,9 @@ exports.searchAdvanced = function (accountId, searchRequest, resultCallback) {
             delete searchRequest.componentIds;
             delete searchRequest.devCompAttributeFilter;
 
-            proxy.dataInquiryAdvanced(searchRequest, function (err, result) {
+            proxy.dataInquiryAdvanced(searchRequest, function (err, result, isBinary) {
                 if (!err) {
-                    resultCallback(null, result);
+                    resultCallback(null, result, isBinary);
                 } else if (result) {
                     resultCallback(err, result);
                 } else {

--- a/public-interface/lib/advancedanalytics-proxy/Metric.data.js
+++ b/public-interface/lib/advancedanalytics-proxy/Metric.data.js
@@ -41,6 +41,9 @@ Metric.prototype.dataAsRoot = function (value) {
     if (value.attributes) {
         dataTemporal.attributes = value.attributes;
     }
+    if (value.dataType === "ByteArray" && value.bValue !== undefined) {
+        dataTemporal.bValue = value.bValue;
+    }
     this.data.push(dataTemporal);
 };
 Metric.prototype.dataAsArray = function (msg) {

--- a/public-interface/lib/cbor/index.js
+++ b/public-interface/lib/cbor/index.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+const cbor = require("cbor");
+const logger = require('../logger').init();
+
+
+var parseCborBody = function(req, res, next) {
+    if (req.headers["content-type"] === "application/cbor") {
+        try {
+            var jsonObject = cbor.decodeFirstSync(req.body);
+            logger.info("Decoded JSON " + jsonObject);
+            req.body = jsonObject;
+        }
+        catch(e) {
+            next(e);
+        }
+        //copy Buffers into "shadow-structure 'binaryValues'"
+        var binaryValues = [];
+        var binValuesIndex = 0;
+        if (req.body.data !== undefined) {
+            req.body.data.forEach((item) => {
+                if (Buffer.isBuffer(item.value)) {
+                    binaryValues.push({
+                        index: binValuesIndex,
+                        value: item.value
+                    });
+                    item.value = binValuesIndex.toString();
+                    binValuesIndex++;
+                }
+            });
+        }
+        if (binaryValues.length > 0) {
+            req.binaryValues = binaryValues;
+        }
+    }
+    next();
+}
+
+module.exports = {
+    parseCborBody: parseCborBody
+};

--- a/public-interface/package.json
+++ b/public-interface/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "*",
     "body-parser": "^1.13.1",
+    "cbor": "^4.1.5",
     "compression": "^1.5.0",
     "continuation-local-storage": "^3.2.1",
     "ejs": "^2.5.5",


### PR DESCRIPTION
* All JSON content can be encoded with CBOR and send to frontend with content-type: application/cbor
* Only "byteArray type" is allowed to have true binary data, i.e. nodejs Buffers
* app.js: Added cbor parsing middleware and body-parser for raw
* cbor/index.js: cbor encoding middleware which is shadowing the Buffers into separate structure (Needed for passing the JSON validations)
* handlers/v1/data.js, api/v1/data: Copying the Buffers back to the JSON body to make sure it can be sent to data backend
* Binary data is shadowed in middleware module and copied back in the data handler. Finally, if binary data is present, data is sent as bValue with cbor to data backend
* Binary coding for search and advancedSearch method

Signed-off-by: Marcel Wagner <wagmarcel@web.de>