### PR TITLE
Inject Span Context to Headers at Data Send

### DIFF
--- a/public-interface/Gruntfile.js
+++ b/public-interface/Gruntfile.js
@@ -400,7 +400,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('build-api', [
         'eslint:local',
-        'jshint:local'
+        'jshint:local',
         'shell:build'
     ]);
 };


### PR DESCRIPTION
Data send now injects the context of its spans into header
so that backend can receive and link its span with them

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>