### PR TITLE
schema-validator: Allow right data types for data send.

### DIFF
--- a/public-interface/engine/api/helpers/componentValuesValidator.js
+++ b/public-interface/engine/api/helpers/componentValuesValidator.js
@@ -34,11 +34,12 @@ var validator = function(dataType, value) {
     };
 
     this.validate = function() {
+        // String encoding is allowed for backward compatibilty
         switch (dataType) {
         case 'Number':
-            return numberValidator(value);
+            return typeof value === "number" || (typeof value === "string" && numberValidator(value));
         case 'Boolean':
-            return booleanValidator(value);
+            return typeof value === "boolean" || (typeof value === "string" && booleanValidator(value));
         case 'String':
             return true;
         case 'ByteArray':

--- a/public-interface/lib/schema-validator/schemas/data.json
+++ b/public-interface/lib/schema-validator/schemas/data.json
@@ -35,7 +35,7 @@
                             }
                         },
                         "value": {
-                            "type": "string",
+                            "type": ["number", "string", "boolean"],
                             "required": true
                         },
                         "attributes": {
@@ -76,7 +76,7 @@
 		"description": "The filter object that will be used to select devices",
 		"examples": [ "criteria or deviceList object" ],
 
-		
+
                 "properties": {
                     "criteria": {
                         "type": "object",


### PR DESCRIPTION
See #105 

The JSON schema expects a string regardless of the actual datatype. This is inefficient and counter-intuitive when the actual data type is a number or boolean.