### PR TITLE
models: Update hostname fiel size in connection bindings

### DIFF
--- a/public-interface/iot-entities/postgresql/models/connectionBindings.js
+++ b/public-interface/iot-entities/postgresql/models/connectionBindings.js
@@ -34,7 +34,7 @@ module.exports = function (sequelize, DataTypes) {
             allowNull: false
         },
         server: {
-            type: DataTypes.STRING(20),
+            type: DataTypes.STRING(50),
             allowNull: false
         },
         connectingStatus: {


### PR DESCRIPTION
The current size (20) was enough for docker, but kubernetes hostnames are longer becasue they follow the name.servicename format

Signed-off-by: Ali Rasim Kocal <arkocal@gmail.com>