### PR TITLE
Frontend kafka

### DIFF
--- a/public-interface/config.js
+++ b/public-interface/config.js
@@ -222,7 +222,7 @@ var config = {
             topicsHeartbeatName: kafka_config.topicsHeartbeatName,
             topicsHeartbeatInterval: kafka_config.topicsHeartbeatInterval
         },
-        ingestion: 'REST',
+        ingestion: 'Kafka',
         userScheme: null // default
     },
     controlChannel: {

--- a/public-interface/package.json
+++ b/public-interface/package.json
@@ -37,7 +37,7 @@
     "http-proxy": "^1.17.0",
     "jaeger-client": "^3.13.0",
     "jsjws": "^5.0.2",
-    "kafka-node": "^3.0.1",
+    "kafka-node": "^5.0.0",
     "methods": "^1.1.2",
     "moment": ">=2.5.1",
     "mqtt": "^2.18.8",


### PR DESCRIPTION
Send data to kafka instead of to the backend. This is a draft as the backend does not have the corresponding functions.

Before/after merge, we can also refactor some config and leave out the REST option (from the frontend) . I do not think we can/should maintain both ways on the long term.