### PR TITLE
Changed Sample count in dashboard

### DIFF
--- a/public-interface/dashboard/public/js/controllers/home.js
+++ b/public-interface/dashboard/public/js/controllers/home.js
@@ -112,8 +112,8 @@ iotController.controller('HomeCtrl', function($scope,
     $scope.$on('$viewContentLoaded', function readyToTrick() {
         $scope.$watch(sessionService.getCurrentAccount, function(data) {
             if (data) {
-                pollerService.startPolling('deviceTotals', devicesService.getTotal);
-                pollerService.startPolling('dataTotals', getMessagesTotal);
+                pollerService.startPolling('deviceTotals', devicesService.getTotal, 60000);
+                pollerService.startPolling('dataTotals', getMessagesTotal, 60000);
             } else {
                 pollerService.stopPolling('dataTotals');
                 pollerService.stopPolling('deviceTotals');

--- a/public-interface/dashboard/public/locale/resourceBundle.json
+++ b/public-interface/dashboard/public/locale/resourceBundle.json
@@ -342,12 +342,9 @@
         "observations_period": "Observations period",
         "details": "Details",
         "period": {
-            "last_hour": "Last hour",
-            "last_day": "Last day",
-            "last_week": "Last week",
-            "last_month": "Last month",
-            "last_year": "Last year",
-            "total": "Total"
+            "last_minute": "Last minute",
+            "last_5minutes": "Last 5 minutes",
+            "last_10minutes": "Last 10 minutes"
         },
         "thereAreAlertsText": "You have %COUNT% unread alerts",
         "moreUnreadAlertsText": "%COUNT% more unread alerts",

--- a/public-interface/engine/api/v1/data.js
+++ b/public-interface/engine/api/v1/data.js
@@ -347,10 +347,13 @@ var getFromDependingOnPeriod = function(period) {
         'last_week':    -3600 * 24 * 7,
         'last_day':     -3600 * 24,
         'last_hour':    -3600,
+        'last_10minutes':  -60 * 10,
+        'last_5minutes':  -60 * 5,
+        'last_minute':  -60,
         'total':         0.0
     };
     if (PERIOD_AS_SECONDS[period]  === undefined) {
-        return PERIOD_AS_SECONDS.last_hour;
+        return PERIOD_AS_SECONDS.last_minute;
     } else {
         return PERIOD_AS_SECONDS[period];
     }


### PR DESCRIPTION
* Originally one could select hourly, weekly, monthly, yearly, total summary
* Sample counting aggregation turns out to be more inefficient with Cassandra than Hbase (on the other hand, writing samples is faster)
* The sample count was triggered every 10 seconds. For larger samples, it took longer to get the summary than 10, so the requests accumulated and slowed down the system
* Workaround is to reduce the sample count periods to 1 minute, 5 minutes, 10 minutes and to trigger the count once per minute
* Long term we need to implement this as beam aggregation service

Signed-off-by: Marcel Wagner <wagmarcel@web.de>