### PR TITLE
Rate limit rework...

### DIFF
--- a/public-interface/admin/index.js
+++ b/public-interface/admin/index.js
@@ -28,6 +28,7 @@ var getUserToken = require('./getUserToken');
 var resetKeycloakUsers = require('./resetKeycloakUsers');
 var importExistingUsersToKeycloak = require('./importExistingUsersToKeycloak');
 var addSystemUsers = require('./addSystemUsers');
+var setAccountRateLimit = require('./setAccountRateLimit');
 var command = process.argv[2];
 var arg = process.argv[3];
 
@@ -74,6 +75,10 @@ case 'importExistingUsersToKeycloak':
     break;
 case 'addSystemUsers':
     addSystemUsers.apply(null, null);
+    break;
+case 'setAccountRateLimit':
+    var arg = process.argv.slice(3);
+    setAccountRateLimit.apply(null, arg);
     break;
 default:
     console.log ("Command : ", command , " not supported ");

--- a/public-interface/admin/setAccountRateLimit.js
+++ b/public-interface/admin/setAccountRateLimit.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const secConfig = require('./../lib/security/config'),
+    postgresProvider = require('../iot-entities/postgresql'),
+    accounts = postgresProvider.accounts,
+    purchasedLimits = postgresProvider.purchasedLimits;
+
+module.exports = function() {
+    if (arguments.length !== 4) {
+        console.error("Not enough arguments : ", arguments);
+        process.exit(1);
+    }
+
+    var accountId = arguments[0];
+    var method = arguments[1].toUpperCase();
+    var path = arguments[2].toLowerCase();
+    var limit = parseInt(arguments[3]);
+
+    if (limit < 0) {
+        console.error("Limit cannot be negative");
+        process.exit(1);
+    }
+
+    if (!secConfig.routes.some(route => route[0] === path && route[1] === method)) {
+        console.error("Route cannot be found: ", method, " - ", path);
+        process.exit(1);
+    }
+
+    accounts.find(accountId, (err) => {
+        if (err) {
+            console.error("Account cannot be found: ", err);
+            process.exit(1);
+        }
+        return purchasedLimits.setLimitForRoute(accountId, path, method, limit).then(() => {
+            console.log("Rate limit set successfully!");
+            process.exit(0);
+        }).catch(err => {
+            console.error("Rate limit could not be set: ", err);
+            process.exit(1);
+        });
+    });
+};

--- a/public-interface/iot-entities/postgresql/models/purchasedLimits.js
+++ b/public-interface/iot-entities/postgresql/models/purchasedLimits.js
@@ -26,11 +26,13 @@ module.exports = function (sequelize, DataTypes) {
         },
         accountId: {
             type: DataTypes.UUID,
-            allowNull: false
+            allowNull: false,
+            unique: 'accountId_route_method_unique'
         },
         route:{
             type: DataTypes.STRING(255),
-            allowNull: false
+            allowNull: false,
+            unique: 'accountId_route_method_unique'
         },
         limit:{
             type: DataTypes.BIGINT,
@@ -38,7 +40,8 @@ module.exports = function (sequelize, DataTypes) {
         },
         method:{
             type: DataTypes.STRING(10),
-            allowNull: false
+            allowNull: false,
+            unique: 'accountId_route_method_unique'
         }
 
     },

--- a/public-interface/iot-entities/postgresql/purchasedLimits.js
+++ b/public-interface/iot-entities/postgresql/purchasedLimits.js
@@ -15,15 +15,13 @@
  */
 
 'use strict';
-var
-    purchasedLimits = require('./models').purchasedLimits;
+var purchasedLimits = require('./models').purchasedLimits;
 
-
-module.exports.getLimitForRoute = function (identity, route, method, resultCallback) {
+module.exports.getLimitForRoute = function (accountId, route, method, resultCallback) {
 
     var query = {
         where: {
-            accountId: identity,
+            accountId: accountId,
             route: route,
             method: method
         }
@@ -35,4 +33,13 @@ module.exports.getLimitForRoute = function (identity, route, method, resultCallb
         }).catch(function (err) {
             resultCallback(err);
         });
+};
+
+module.exports.setLimitForRoute = function (accountId, route, method, limit) {
+    return purchasedLimits.upsert({
+        accountId: accountId,
+        route: route,
+        method: method,
+        limit: limit,
+    });
 };


### PR DESCRIPTION
- Users/Devices have a global rate limit to prevent spamming
- Accounts have purchasable rate limits, users/devices use when they make a request to the account
- Removed user based purchasable rate limit
- Added admin tool for setting rate limits for accounts

Signed-off-by: Oguzcan Kirmemis <oguzcan.kirmemis@gmail.com>