### PR TITLE
Changes in Alert storage and API

### DIFF
--- a/public-interface/dashboard/public/js/services/alerts_service.js
+++ b/public-interface/dashboard/public/js/services/alerts_service.js
@@ -15,6 +15,7 @@
  */
 
 'use strict';
+const MAX_ALERTS = 100; // Max amount of alerts to return - hardcoded :-(
 iotServices.factory('alertsService', ['$http', 'utilityService','sessionService', function($http, utilityService, sessionService){
     var fireStatusUpdatedEvent = function(ngScope, data) {
         if (ngScope) {
@@ -41,7 +42,8 @@ iotServices.factory('alertsService', ['$http', 'utilityService','sessionService'
                         url: url,
                         params: {
                             "_" : utilityService.timeStamp(),
-                            "active": true
+                            "active": true,
+                            "maxAlerts": MAX_ALERTS
                         }
                     }).success(function(data){
                         summary.unread = data;
@@ -58,7 +60,8 @@ iotServices.factory('alertsService', ['$http', 'utilityService','sessionService'
                         url: url,
                         params: {
                             "_" : utilityService.timeStamp(),
-                            "active": true
+                            "active": true,
+                            "maxAlerts": MAX_ALERTS
                         }
                     }).success(function(data) {
                         summary.unread = removeReadAlerts(data);

--- a/public-interface/doc/api/alerts.raml
+++ b/public-interface/doc/api/alerts.raml
@@ -21,6 +21,10 @@ uriParameters:
     description: |
       The ID of an Account. In order to obtain the Account Id, we need first obtain an Authorization Token and then get the Authorization Token Info
     example: 321ef007-8449-477f-9ea0-d702d77e64b9
+ queryParameters:
+   maxAlerts:
+     description: |
+       Maximal amount of alerts to return. Ordered by creation time, descending.
 get:
   description: |
     **Get List of Alerts**

--- a/public-interface/engine/handlers/v1/alerts.js
+++ b/public-interface/engine/handlers/v1/alerts.js
@@ -111,6 +111,12 @@ exports.getAlerts = function(req, res, next) {
     if (req.query.active) {
         params.active = req.query.active;
     }
+
+    // query parameter maxAlerts to limit amount of returned alerts
+    if (req.query.maxAlerts) {
+        params.maxAlerts = req.query.maxAlerts;
+    }
+
     alert.getAlerts(params, function(err, result){
         if(!err && result){
             res.status(httpStatuses.OK.code).send(result);

--- a/public-interface/iot-entities/postgresql/alerts.js
+++ b/public-interface/iot-entities/postgresql/alerts.js
@@ -53,7 +53,7 @@ exports.new = function (newAlert, callback) {
 
 };
 
-exports.findByStatus = function (accountId, status, isActive, callback) {
+exports.findByStatus = function (accountId, status, isActive, maxAlerts, callback) {
     var filter = {
         where: {
             accountId: accountId
@@ -66,6 +66,10 @@ exports.findByStatus = function (accountId, status, isActive, callback) {
     }
     if (isActive) {
         filter.where["suppressed"] = false;
+    }
+
+    if (maxAlerts !== undefined) {
+        filter.limit = maxAlerts;
     }
 
     return alerts.findAll(filter)


### PR DESCRIPTION
* Suppressed Alerts are no longer stored in db
* getAlerts has not queryParameter maxAlerts to limit the number of returned alerts
* Dashboard display max 100 alerts, starting with most recent, descending

Signed-off-by: Marcel Wagner <wagmarcel@web.de>